### PR TITLE
Fix incorrect commands in the documentation

### DIFF
--- a/vitepress/docs/wayland.md
+++ b/vitepress/docs/wayland.md
@@ -29,6 +29,6 @@ bind = ALT, C, exec, grim -g "$(slurp)" ~/.cache/com.pot-app.desktop/pot_screens
 由于目前 pot 在 Wayland 下还无法获取到正确的鼠标坐标，所以内部的实现无法工作。 对于某些桌面环境/窗口管理器，可以通过设置窗口规则来实现窗口跟随鼠标位置，这里以 Hyprland 为例：
 
 ```ini
-windowrulev2 = float, class:(pot), title:(Translator|OCR|PopClip|Screenshot Translate) # Translation window floating
-windowrulev2 = move cursor 0 0, class:(pot), title:(Translator|PopClip|Screenshot Translate) # Translation window follows the mouse position.
+windowrulev2 = float, class:(pot), title:(Translate|OCR|PopClip|Screenshot Translate) # Translation window floating
+windowrulev2 = move cursor 0 0, class:(pot), title:(Translate|PopClip|Screenshot Translate) # Translation window follows the mouse position.
 ```


### PR DESCRIPTION
The title of the translation window should be Translate

This pull request makes a minor update to the documentation for configuring window rules in Hyprland. The change clarifies the matching window title by replacing "Translator" with "Translate" in the configuration examples.

<img width="298" height="128" alt="图片" src="https://github.com/user-attachments/assets/8b407035-7c09-4382-b622-5f7fa2a2c942" />

在Arch Wayland中测试


